### PR TITLE
bugfix : date de début incorrecte lors de l'édition d'une résa sur pl…

### DIFF
--- a/edit_entry.php
+++ b/edit_entry.php
@@ -896,7 +896,7 @@ echo '</td></tr>'.PHP_EOL;
 echo '<tr><td class="CL">'.PHP_EOL;
 
 echo '<div class="form-group">'.PHP_EOL;
-jQuery_DatePicker('start');
+jQuery_DatePicker('start', $start_day, $start_month, $start_year);
 echo '</div>'.PHP_EOL;
 echo '<div class="form-group">'.PHP_EOL;
 

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -4966,23 +4966,25 @@ function affiche_nom_prenom_email($_beneficiaire, $_beneficiaire_ext, $type = "n
  	}
  	else
  	{
- 		if (isset ($_GET['day']))
- 			$day = $_GET['day'];
- 		else if (!is_null($startDay))
+ 		if (!is_null($startDay))
             $day = $startDay;
-        else
+        else if (isset ($_GET['day']))
+ 			$day = $_GET['day'];
+ 		else
  			$day = date("d");
- 		if (isset ($_GET['month']))
- 			$month = $_GET['month'];
- 		else if (!is_null($startMonth))
+
+ 		if (!is_null($startMonth))
             $month = $startMonth;
-        else
+        else if (isset ($_GET['month']))
+ 			$month = $_GET['month'];
+ 		else
  			$month = date("m");
- 		if (isset ($_GET['year']))
- 			$year = $_GET['year'];
- 		else if (!is_null($startYear))
+
+ 		if (!is_null($startYear))
             $year = $startYear;
-        else
+        else if (isset ($_GET['year']))
+ 			$year = $_GET['year'];
+ 		else
  			$year = date("Y");
  	}
  	genDateSelector("".$typeDate."_", "$day", "$month", "$year","");

--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -4922,7 +4922,7 @@ function affiche_nom_prenom_email($_beneficiaire, $_beneficiaire_ext, $type = "n
  		return $_statut;
  }
 
- function jQuery_DatePicker($typeDate)
+ function jQuery_DatePicker($typeDate, $startDay = NULL, $startMonth = NULL, $startYear = NULL)
  {
 
 	 if (@file_exists('../include/connect.inc.php')){
@@ -4968,15 +4968,21 @@ function affiche_nom_prenom_email($_beneficiaire, $_beneficiaire_ext, $type = "n
  	{
  		if (isset ($_GET['day']))
  			$day = $_GET['day'];
- 		else
+ 		else if (!is_null($startDay))
+            $day = $startDay;
+        else
  			$day = date("d");
  		if (isset ($_GET['month']))
  			$month = $_GET['month'];
- 		else
+ 		else if (!is_null($startMonth))
+            $month = $startMonth;
+        else
  			$month = date("m");
  		if (isset ($_GET['year']))
  			$year = $_GET['year'];
- 		else
+ 		else if (!is_null($startYear))
+            $year = $startYear;
+        else
  			$year = date("Y");
  	}
  	genDateSelector("".$typeDate."_", "$day", "$month", "$year","");


### PR DESCRIPTION
…usieurs jours

Voir le ticket iTop 36683 : quand on modifie une réservation qui s'étale sur plusieurs jours (pas une réservation récurrente mais une unique dont la durée est en jour) en cliquant sur une de ses cases dans la vue hebdomadaire, la durée renseignée est bien la durée définie mais la date de départ qui apparait dans la formulaire est la date du jour correspondant à la case cliquée et non la véritable date de départ (qui est dans le passé).

Cause : la fonction jQuery_DatePicker, qui génère le morceau de formulaire relatif à la date de début, ne reçoit pas d'information relative à la date déjà enregistrée, contrairement à jQuery_TimePicker qui dispose de paramètres pour cela. De plus, cette fonction ne va chercher des informations dans la BDD que si elle est appelée pour traiter le cas de la date de fin de périodicité.

Solution : ajouter à jQuery_DatePicker des paramètres pour recevoir la date à prérégler dans le formulaire, et modifier l'appel à cette fonction en conséquence. Les nouveaux paramètres sont facultatifs pour ne pas casser d'autres appels éventuel ailleurs dans le code.

Limitation : code non testé ; j'ai regardé rapidement dans edit_entry.php que les variables que je passe en paramètre ont toujours reçu une valeur pertinent à ce moment, mais je n'ai pas fait une vérification approfondie.
